### PR TITLE
Throw error on process.exit()

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,6 +85,10 @@ function planify(data) {
                 }
 
                 process.exit(err.exitCode || 1);
+
+                // This is necessary if the `process.exit()` is being mocked. This way it is possible
+                // to catch the error and assert it accordingly.
+                throw err;
             })
             .return(plan.node.data)
             .nodeify(done);

--- a/test/functional.js
+++ b/test/functional.js
@@ -292,7 +292,7 @@ describe('functional', () => {
                 .step('step 1', () => { throw new Error('foo'); })
                 .run({ reporter: 'silent', exit: true });
             })
-            .then(() => {
+            .catch(() => {
                 return planify()
                 .step('step 1', () => {
                     const err = new Error('foo');
@@ -302,11 +302,14 @@ describe('functional', () => {
                 })
                 .run({ reporter: 'silent', exit: true });
             })
+            .then(() => {
+                throw new Error('Should have failed');
+            }, (err) => {
+                expect(err.message).to.eql('foo');
+                expect(exitCodes).to.eql([0, 1, 25]);
+            })
             .finally(() => {
                 process.exit = originalExit;
-            })
-            .then(() => {
-                expect(exitCodes).to.eql([0, 1, 25]);
             });
         });
     });


### PR DESCRIPTION
This throws the error on process.exit even if the `exit` option is set to be true. A valid use case is to make it possible to assert the error if the `process.exit()` is being mocked during tests.